### PR TITLE
chore: remove dupe dependency file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/python-36
 
 WORKDIR /app
 
-COPY requirements.txt /tmp/requirements.txt
+COPY Pipfile* /app/
 
 ## NOTE - rhel enforces user container permissions stronger ##
 USER root
@@ -10,7 +10,7 @@ RUN yum -y install python3-pip wget
 
 RUN pip install --upgrade pip \
   && pip install --upgrade pipenv \
-  && pip install --upgrade -r /tmp/requirements.txt
+  && pipenv install --system --deploy --ignore-pipfile
 
 USER 1001
 

--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi
 
 WORKDIR /app
 
-COPY requirements.txt /tmp/requirements.txt
+COPY Pipfile* /app/
 
 # Install python 3
 RUN yum -y install --disableplugin=subscription-manager python36 \
@@ -12,7 +12,8 @@ RUN yum -y install --disableplugin=subscription-manager python36 \
 RUN yum -y install --disableplugin=subscription-manager python3-pip wget \
   && yum --disableplugin=subscription-manager clean all
 
-RUN pip3 install --upgrade -r /tmp/requirements.txt
+RUN pip3 install pipenv
+RUN pipenv install --system --deploy --ignore-pipfile
 
 # Update python command to point to python3 install
 RUN alternatives --set python /usr/bin/python3

--- a/Pipfile
+++ b/Pipfile
@@ -1,19 +1,16 @@
 [[source]]
-
-url = "https://pypi.python.org/simple"
-verify_ssl = true
 name = "pypi"
-
+url = "https://pypi.org/simple"
+verify_ssl = true
 
 [dev-packages]
 
-
 [packages]
-livereload ='*'
-ibmcloudenv ='~=0.0'
-Django = ">=2.2.8"
 gunicorn = "==19.7.1"
-whitenoise= "==5.0"
+whitenoise = "==5.0"
+ibmcloudenv = "*"
+livereload = "*"
+Django = ">=2.2.8"
 
 [requires]
-python_version = '3.6.2'
+python_version = ">=3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,121 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "c27c90cf1ce47c7b5c4bea63239f33fd496d4550d9c77f6386186911179d177b"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": ">=3"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:7e06d934a7718bf3975acbf87780ba678957b87c7adc056f13b6215d610695a0",
+                "sha256:ea448f92fc35a0ef4b1508f53a04c4670255a3f33d22a81c8fc9c872036adbe5"
+            ],
+            "version": "==3.2.3"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
+                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
+            ],
+            "version": "==4.4.1"
+        },
+        "django": {
+            "hashes": [
+                "sha256:4f2c913303be4f874015993420bf0bd8fd2097a9c88e6b49c6a92f9bdd3fb13a",
+                "sha256:8c3575f81e11390893860d97e1e0154c47512f180ea55bd84ce8fa69ba8051ca"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
+                "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
+            ],
+            "index": "pypi",
+            "version": "==19.7.1"
+        },
+        "ibmcloudenv": {
+            "hashes": [
+                "sha256:a8b453b0b8b886545b8af47f64f425eb88351acc0b714336936fd6171ec7560e",
+                "sha256:e008fe44c6c62cbfc632437a8877277786c901deb68f5f45e1fda8cb6be1bc4e"
+            ],
+            "index": "pypi",
+            "version": "==0.2.1"
+        },
+        "jsonpath-rw": {
+            "hashes": [
+                "sha256:05c471281c45ae113f6103d1268ec7a4831a2e96aa80de45edc89b11fac4fbec"
+            ],
+            "version": "==1.4.0"
+        },
+        "livereload": {
+            "hashes": [
+                "sha256:78d55f2c268a8823ba499305dcac64e28ddeb9a92571e12d543cd304faf5817b",
+                "sha256:89254f78d7529d7ea0a3417d224c34287ebfe266b05e67e51facaf82c27f0f66"
+            ],
+            "index": "pypi",
+            "version": "==2.6.1"
+        },
+        "ply": {
+            "hashes": [
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+            ],
+            "version": "==3.11"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
+                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+            ],
+            "version": "==0.3.0"
+        },
+        "tornado": {
+            "hashes": [
+                "sha256:349884248c36801afa19e342a77cc4458caca694b0eda633f5878e458a44cb2c",
+                "sha256:398e0d35e086ba38a0427c3b37f4337327231942e731edaa6e9fd1865bbd6f60",
+                "sha256:4e73ef678b1a859f0cb29e1d895526a20ea64b5ffd510a2307b5998c7df24281",
+                "sha256:559bce3d31484b665259f50cd94c5c28b961b09315ccd838f284687245f416e5",
+                "sha256:abbe53a39734ef4aba061fca54e30c6b4639d3e1f59653f0da37a0003de148c7",
+                "sha256:c845db36ba616912074c5b1ee897f8e0124df269468f25e4fe21fe72f6edd7a9",
+                "sha256:c9399267c926a4e7c418baa5cbe91c7d1cf362d505a1ef898fde44a07c9dd8a5"
+            ],
+            "version": "==6.0.3"
+        },
+        "whitenoise": {
+            "hashes": [
+                "sha256:1ecfc1d9e16b71a4efc499e1f62a6a06e7728a475d39cb0657ce71e7529f0f08",
+                "sha256:7c75090c09f58a261dfece4e12b2c46534ca9d70b3c4b5c2cfca89b59b446498"
+            ],
+            "index": "pypi",
+            "version": "==5.0"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To get started building this application locally, you can either run the applica
 Running Django applications has been simplified with a `manage.py` file to avoid dealing with configuring environment variables to run your app. From your project root, you can download the project dependencies with:
 
 ```bash
-pip install -r requirements.txt
+pipenv install --system --deploy --ignore-pipfile
 ```
 
 To run your application locally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-Django>=2.2.8
-gunicorn==19.7.1
-whitenoise==5.0
-ibmcloudenv
-livereload


### PR DESCRIPTION
Change the package installer from `pip` to `pipenv` and eliminate the use of the "requirements.txt" file.