### PR TITLE
Fix Selenium test (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://cloud.ibm.com">
-        <img src="https://landscape.cncf.io/logos/ibm-cloud-kcsp.svg" height="100" alt="IBM Cloud">
+        <img src="https://my1.digitalexperience.ibm.com/8304c341-f896-4e04-add0-0a9ae02473ba/dxdam/2d/2d559197-6763-4e47-a2cb-8f54c449ff26/ibm-cloud.svg" height="100" alt="IBM Cloud">
     </a>
 </p>
 
@@ -112,4 +112,3 @@ ibmcloud dev debug
 This sample application is licensed under the Apache License, Version 2. Separate third-party code objects invoked within this code pattern are licensed by their respective providers pursuant to their own separate licenses. Contributions are subject to the [Developer Certificate of Origin, Version 1.1](https://developercertificate.org/) and the [Apache License, Version 2](https://www.apache.org/licenses/LICENSE-2.0.txt).
 
 [Apache License FAQ](https://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN)
-

--- a/scripts/python_django.py
+++ b/scripts/python_django.py
@@ -11,17 +11,24 @@ options.add_argument('--disable-dev-shm-usage')
 driver = webdriver.Chrome(options=options)
 driver.get(os.environ["APP_URL"]); # Open a browser to the app's landing page
 time.sleep(3)
-# Verify the expected content is present
-title_text = driver.find_element_by_css_selector('h1.title').text
-print("The title text is: {}".format(title_text))
-if title_text == "Congratulations!":
-    print("Experience Test Successful")
-else:
-    sys.exit("Experience Test Failed")
 
-subtitle_text = driver.find_element_by_css_selector('h2.subtitle').text
-print("The subtitle text is: {}".format(subtitle_text))
-if subtitle_text == "You are currently running a Django server.":
-    print("Experience Test Successful")
+# Verify the expected content is present
+title_text = driver.find_elements_by_xpath('//h1[@class="title"]')[0].text
+if len(title_text) == 0:
+    sys.exit("Experience Test Failed: no title texts found")
 else:
-    sys.exit("Experience Test Failed")
+    print("The title text is: {}".format(title_text))
+    if title_text == "Congratulations!":
+        print("Experience Test Successful")
+    else:
+        sys.exit("Experience Test Failed: unexpected subtitle text {}".format(title_text))
+
+subtitle_text = driver.find_elements_by_xpath('//h2[@class="subtitle"]')[0].text
+if len(subtitle_text) == 0:
+    sys.exit("Experience Test Failed: no subtitle texts found")
+else:
+    print("The subtitle text is: {}".format(subtitle_text))
+    if subtitle_text == "You are currently running a Django server.":
+        print("Experience Test Successful")
+    else:
+        sys.exit("Experience Test Failed: unexpected subtitle text {}".format(subtitle_text))


### PR DESCRIPTION
* Update README.md

* fix: find element

* chore: dummy change to trigger monitoring

* chore: dummy change to trigger monitoring (#40)

* fix: lookup landing page elems by tag name (#41)

* docs(readme): update logo src (#42)

* fix: lookup landing page elems by tag name (#43)

* chore: dummy change to trigger monitoring

* fix: lookup landing page elems by tag name (#41)

* docs(readme): update logo src (#42)

Co-authored-by: Joseph Meis <jmeis@users.noreply.github.com>

* fix: typo in driver call (#44)

* fix: changed to xpath

Results from my manual test:  
```
Congratulations!
You are currently running a Django server.
The length of h1 is: 16
The length of h2 is: 42
```

* fix: var typo

Co-authored-by: Joseph Meis <jmeis@users.noreply.github.com>
Co-authored-by: Nick Steinhauser <nicksteinhauser@gmail.com>
Co-authored-by: Gabriel Valencia <gee4vee@me.com>