### PR TITLE
fix: local build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY Pipfile* /opt/app-root/src/
 ## NOTE - rhel enforces user container permissions stronger ##
 USER root
 
-RUN pip3 install --upgrade pip==21.0.1 \
+RUN pip3 install --upgrade pip==21.3.1 \
   && pip3 install --upgrade pipenv==2020.11.15 \
   && pipenv install --deploy
 

--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -9,8 +9,9 @@ USER root
 RUN yum -y install --disableplugin=subscription-manager wget \
   && yum --disableplugin=subscription-manager clean all
 
-RUN pip3 install pipenv
-RUN pipenv install --dev
+RUN pip3 install --upgrade pip==21.3.1 \
+  && pip3 install --upgrade pipenv==2020.11.15 \
+  && pipenv install --dev
 
 # Update python command to point to python3 install
 RUN alternatives --set python /usr/bin/python3


### PR DESCRIPTION
Fixes this error: 
```
FileNotFoundError: [Errno 2] No such file or directory: '/opt/app-root/lib64/python3.9/site-packages/pip/_vendor/certifi/cacert.pem'
The command '/bin/sh -c pipenv install --dev' returned a non-zero code: 1
FAILED
An error exit status 1 was encountered while building the Docker image.
```